### PR TITLE
update page titles

### DIFF
--- a/components/blog/with-post.js
+++ b/components/blog/with-post.js
@@ -106,7 +106,7 @@ export default meta => ({ children }) => {
 
   return (
     <MDXProvider components={components}>
-      <Page title={meta.title + ' - Next.js Blog'}>
+      <Page title={`Next.js - Blog - ${meta.title}`}>
         <SocialMeta
           image={'/static' + meta.link + '/twitter-card.png'}
           {...meta}

--- a/components/docs/head.js
+++ b/components/docs/head.js
@@ -1,17 +1,14 @@
-import Head from 'next/head'
+import Head from 'next/head';
 
 export default ({ children, ...props }) => (
   <Head>
-    <title>{`${props.title} - Next.js Documentation`}</title>
+    <title>{`Next.js - Documentation - ${props.title}`}</title>
     <meta
       name="twitter:card"
       content={props.image ? 'summary_large_image' : 'summary'}
     />
     <meta name="twitter:site" content="@zeithq" />
-    <meta
-      name="og:title"
-      content={props.ogTitle || props.title}
-    />
+    <meta name="og:title" content={props.ogTitle || props.title} />
     {props.description ? (
       <meta name="description" content={props.description} />
     ) : null}
@@ -22,12 +19,12 @@ export default ({ children, ...props }) => (
     )}
     {props.video
       ? [
-        <meta name="og:type" content="video" key="0" />,
-        <meta name="og:video" content={props.video} key="1" />,
-        <meta name="og:video:type" content="video/mp4" key="2" />
-      ]
+          <meta name="og:type" content="video" key="0" />,
+          <meta name="og:video" content={props.video} key="1" />,
+          <meta name="og:video:type" content="video/mp4" key="2" />
+        ]
       : null}
 
-    { children }
+    {children}
   </Head>
-)
+);

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -12,7 +12,6 @@ export default class NextSite extends Document {
             name="viewport"
             content="width=device-width, initial-scale=1.0"
           />
-          <title>Next.js</title>
 
           <link
             rel="apple-touch-icon"


### PR DESCRIPTION
- Removed `<title>` from _document to stop error: https://github.com/zeit/next.js/blob/master/errors/no-document-title.md
- Documentation only has that one sub page (Getting Started), so it could be simplified to just "Next.js - Documentation", but leaving as-is since they might have set it up like that for future use.
- Alternative formats could be "Next.js Blog - Blog Post 3" or we go with something like what's on `/learn` and [zeit.co](https://zeit.co/docs): "Blog Post 3 - Next.js Blog"

TODO
--
- The `/learn` route doesn't seem to be part of this app? The title formatting there will need to be updated.